### PR TITLE
[Gigya] GigyaSocialProviders initializer should lowerCase its rawValue parameter

### DIFF
--- a/Gigya.podspec
+++ b/Gigya.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = 'Gigya'
-  spec.version       = '1.1.6'
+  spec.version       = '1.1.7'
   spec.license       = 'Apache 2.0'
   spec.homepage      = 'https://developers.gigya.com/display/GD/Swift+SDK'
   spec.author       = 'Gigya SAP'

--- a/GigyaSwift/Models/GigyaSocialProviders.swift
+++ b/GigyaSwift/Models/GigyaSocialProviders.swift
@@ -87,7 +87,7 @@ public enum GigyaSocialProviders {
     }
 
     public init?(rawValue: String) {
-        switch rawValue {
+        switch rawValue.lowercased() {
         case "facebook":
             self = .facebook
         case "google", "googleplus":
@@ -124,15 +124,15 @@ public enum GigyaSocialProviders {
             self = .netlog
         case "odnoklassniki":
             self = .odnoklassniki
-        case "orangeFrance":
+        case "orangefrance":
             self = .orangeFrance
         case "paypaloauth":
             self = .paypaloauth
-        case "tencentQq":
+        case "tencentqq":
             self = .tencentQq
         case "renren":
             self = .renren
-        case "sinaWeibo":
+        case "sinaweibo":
             self = .sinaWeibo
         case "spiceworks":
             self = .spiceworks
@@ -142,7 +142,7 @@ public enum GigyaSocialProviders {
             self = .wordpress
         case "xing":
             self = .xing
-        case "yahooJapan":
+        case "yahoojapan":
             self = .yahooJapan
         case "apple":
             self = .apple


### PR DESCRIPTION
Please see #14 for the reasoning behind this PR.
Let's make GigyaSocialProviders.init?(rawValue: String) safer, and lowerCase the rawValue input to avoid casing mistakes.