### PR TITLE
Clear Cookies only on logout

### DIFF
--- a/GigyaSwift/Global/Api/BusinessApiService.swift
+++ b/GigyaSwift/Global/Api/BusinessApiService.swift
@@ -287,6 +287,7 @@ class BusinessApiService: NSObject, BusinessApiServiceProtocol {
         let model = ApiRequestModel(method: GigyaDefinitions.API.logout, params: [:])
         apiService.send(model: model, responseType: GigyaDictionary.self) { [weak self] result in
             self?.sessionService.clear()
+            self?.sessionService.clearCookies()
             self?.biometricService.clearBiometric()
             
             switch result {

--- a/GigyaSwift/Global/Session/SessionService.swift
+++ b/GigyaSwift/Global/Session/SessionService.swift
@@ -297,9 +297,6 @@ class SessionService: SessionServiceProtocol {
         // clear account from cach
         accountService.clear()
 
-        // clear all cookies created in WKWebView
-        clearCookies()
-
         // clear session from memory
         self.session = nil
     }
@@ -317,7 +314,7 @@ class SessionService: SessionServiceProtocol {
         }
     }
 
-    private func clearCookies() {
+    func clearCookies() {
         if clearCookiesEnable {
             DispatchQueue.main.async {
                 HTTPCookieStorage.shared.removeCookies(since: .distantPast)

--- a/GigyaSwift/Global/Session/SessionServiceProtocol.swift
+++ b/GigyaSwift/Global/Session/SessionServiceProtocol.swift
@@ -28,6 +28,8 @@ public protocol SessionServiceProtocol {
 
     func clearSession()
 
+    func clearCookies()
+    
     func setClearCookies(to value: Bool)
 
 }

--- a/GigyaSwiftTests/Services/SessionServiceMock.swift
+++ b/GigyaSwiftTests/Services/SessionServiceMock.swift
@@ -43,5 +43,7 @@ class SessionServiceMock: SessionServiceProtocol {
 
     }
 
+    func clearCookies() {
 
+    }
 }


### PR DESCRIPTION
### Summary

This PR modifies the cookie clearing behavior to make it more consistent with the behavior observed in the Gigya Android SDKs. Specifically, it removes the unexpected cookie clearing during the implicit initialization when a session has expired but the user has not logged out.

### Motivation 

We have encountered unexpected cookie clearing from the Gigya SDK during implicit initialization. This situation arises from the `SessionService.clearCookies()` method, which is invoked from `SessionService.startSessionCountdownTimerIfNeeded()`, when `if !session.isValid()` is true. The session is invalid because it has expired (`GigyaSession.isValid()` returns `false`).

In our view, device cookie clearing should occur upon logout, not when the session expires. This logic aligns with the Android SDK's behaviour, which we also use and where we do not encounter any issues. A comparative analysis of the iOS and Android SDKs has revealed this discrepancy.

It's worth noting that utilizing `Gigya.sharedInstance().setClearCookies(to: false)` does not solve the issue, as it only alters the behaviour after explicit `init` completion, while the unexpected clearing takes place during the "implicit" `init`.

### Modifications

Below are the suggested modifications, along with references to the Android SDK for context.

#### 1. Remove cookie clearing from session clearing.

The `SessionService.clearSession()` method is invoked when the session expires and should not clear the cookies.

Android code reference: [`SessionService.java` line 282](https://github.com/SAP/gigya-android-sdk/blob/beb07011ac7575e3d91768fbb21e17d60ec8be45/sdk-core/src/main/java/com/gigya/android/sdk/session/SessionService.java#L282C10-L282C10).
No cookie clearing is present during session clearing.

#### 2. Implement cookie clearing upon user logout.

The `BusinessApiService.logOut(completion:)` method should explicitly clear the cookies. Previously, logout triggered `sessionService.clear()`, which cleared cookies. However, this does not allow the separation of cookie clearing from session expiration. By moving the cookie clearing call directly to `BusinessApiService`, we enforce it only upon user logout, eliminating the unexpected behaviour.

Android code reference: [`SessionService.java` line 294](https://github.com/SAP/gigya-android-sdk/blob/beb07011ac7575e3d91768fbb21e17d60ec8be45/sdk-core/src/main/java/com/gigya/android/sdk/session/SessionService.java#L294C8-L294C8).
The only instances where cookies can be cleared are from `clearCookiesOnLogout()`, which in turn is invoked from only two places:
1. [Gigya.java line 395](https://github.com/SAP/gigya-android-sdk/blob/beb07011ac7575e3d91768fbb21e17d60ec8be45/sdk-core/src/main/java/com/gigya/android/sdk/Gigya.java#L395) - for logout.
2. [GigyaWebBridge.java line 353](https://github.com/SAP/gigya-android-sdk/blob/beb07011ac7575e3d91768fbb21e17d60ec8be45/sdk-core/src/main/java/com/gigya/android/sdk/ui/plugin/GigyaWebBridge.java#L353) - for web-bridge logout.

For the iOS SDK, both of these logout flows invoke `BusinessApiService.logOut(completion:)`, ensuring cookies will be cleared in all logout scenarios as expected.